### PR TITLE
Integrate API content and trading chart

### DIFF
--- a/src/lib/features/brokers/screens/brokers_screen.dart
+++ b/src/lib/features/brokers/screens/brokers_screen.dart
@@ -4,11 +4,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../shared/balance_view.dart';
 import '../bloc/brokers_cubit.dart';
-import 'package:dio/dio.dart';
-
 import '../data/brokers_data_provider.dart';
 import '../data/brokers_repository.dart';
 import '../widgets/broker_card.dart';
+import '../../shared/api_client.dart';
 
 /// Screen that displays available brokers and allows opening them in WebView.
 class BrokersScreen extends StatelessWidget {
@@ -16,12 +15,7 @@ class BrokersScreen extends StatelessWidget {
       : _repository = repository ??
             BrokersRepository(
               HttpBrokersDataProvider(
-                Dio(
-                  BaseOptions(
-                    baseUrl:
-                        'https://us-central1-fx-trading-study.cloudfunctions.net',
-                  ),
-                ),
+                createApiClient(),
               ),
             );
 

--- a/src/lib/features/learning/article.dart
+++ b/src/lib/features/learning/article.dart
@@ -1,15 +1,20 @@
 class Article {
-  Article({required this.id, required this.title, required this.reward, required this.content});
+  Article({required this.id, required this.title, required this.reward, required this.url});
 
   final String id;
   final String title;
   final double reward;
-  final String content;
+  final String url;
 
   factory Article.fromJson(Map<String, dynamic> json) => Article(
-        id: json['id'] as String,
+        id: json['alias'] as String,
         title: json['title'] as String,
-        reward: (json['reward'] as num).toDouble(),
-        content: json['content'] as String,
+        reward: _parseReward(json['reward'] as String),
+        url: json['url'] as String,
       );
+
+  static double _parseReward(String reward) {
+    final match = RegExp(r'(\d+(\.\d+)?)').firstMatch(reward);
+    return match != null ? double.parse(match.group(0)!) : 0;
+  }
 }

--- a/src/lib/features/learning/article_detail_page.dart
+++ b/src/lib/features/learning/article_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 import '../shared/balance_view.dart';
 import '../balance/balance_cubit.dart';
@@ -17,33 +18,50 @@ class ArticleDetailPage extends StatefulWidget {
 
 class _ArticleDetailPageState extends State<ArticleDetailPage> {
   bool rewarded = false;
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..loadRequest(Uri.parse(widget.article.url));
+  }
+
+  Future<bool> _handlePop() async {
+    if (!rewarded) {
+      rewarded = true;
+      context.read<BalanceCubit>().add(widget.article.reward);
+    }
+    return true;
+  }
+
+  @override
+  void dispose() {
+    if (!rewarded) {
+      context.read<BalanceCubit>().add(widget.article.reward);
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.article.title),
-        actions: const [BalanceView()],
-      ),
-      body: NotificationListener<ScrollNotification>(
-        onNotification: (notification) {
-          if (!rewarded && notification.metrics.pixels >= notification.metrics.maxScrollExtent) {
-            rewarded = true;
-            context.read<BalanceCubit>().add(widget.article.reward);
-          }
-          return false;
-        },
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(tr('lesson.reward', namedArgs: {'reward': widget.article.reward.toStringAsFixed(0)})),
-              const SizedBox(height: 16),
-              Text(widget.article.content),
-              const SizedBox(height: 300), // extra space to allow scroll completion
-            ],
-          ),
+    return WillPopScope(
+      onWillPop: _handlePop,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.article.title),
+          actions: const [BalanceView()],
+        ),
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(tr('lesson.reward',
+                  namedArgs: {'reward': widget.article.reward.toStringAsFixed(0)})),
+            ),
+            Expanded(child: WebViewWidget(controller: _controller)),
+          ],
         ),
       ),
     );

--- a/src/lib/features/learning/articles_repository.dart
+++ b/src/lib/features/learning/articles_repository.dart
@@ -1,13 +1,19 @@
-import 'dart:convert';
+import 'package:dio/dio.dart';
 
-import 'package:flutter/services.dart';
-
+import '../shared/api_client.dart';
 import 'article.dart';
 
+/// Repository that loads articles from the backend API.
 class ArticlesRepository {
+  ArticlesRepository({Dio? dio}) : _dio = dio ?? createApiClient();
+
+  final Dio _dio;
+
   Future<List<Article>> loadArticles() async {
-    final data = await rootBundle.loadString('assets/articles.json');
-    final list = json.decode(data) as List<dynamic>;
-    return list.map((e) => Article.fromJson(e as Map<String, dynamic>)).toList();
+    final response = await _dio.get<List<dynamic>>('/api/articles');
+    final data = response.data ?? [];
+    return data
+        .map((e) => Article.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/src/lib/features/learning/learn_screen.dart
+++ b/src/lib/features/learning/learn_screen.dart
@@ -44,10 +44,13 @@ class _LearnScreenState extends State<LearnScreen> {
       body: FutureBuilder<List<Article>>(
         future: _future,
         builder: (context, snapshot) {
-          if (!snapshot.hasData) {
+          if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          final articles = snapshot.data!;
+          if (snapshot.hasError) {
+            return Center(child: Text(snapshot.error.toString()));
+          }
+          final articles = snapshot.data ?? [];
           return RefreshIndicator(
             onRefresh: _refresh,
             child: ListView.builder(

--- a/src/lib/features/shared/api_client.dart
+++ b/src/lib/features/shared/api_client.dart
@@ -1,0 +1,7 @@
+import 'package:dio/dio.dart';
+
+/// Base URL for backend API.
+const apiBaseUrl = 'https://us-central1-fx-trading-study.cloudfunctions.net';
+
+/// Creates a Dio client configured for the backend.
+Dio createApiClient() => Dio(BaseOptions(baseUrl: apiBaseUrl));

--- a/src/lib/features/trade/forex_quote.dart
+++ b/src/lib/features/trade/forex_quote.dart
@@ -1,0 +1,11 @@
+class ForexQuote {
+  ForexQuote({required this.symbol, required this.price});
+
+  final String symbol;
+  final double price;
+
+  factory ForexQuote.fromJson(Map<String, dynamic> json) => ForexQuote(
+        symbol: json['s'] as String,
+        price: double.parse(json['c'] as String),
+      );
+}

--- a/src/lib/features/trade/trade_screen.dart
+++ b/src/lib/features/trade/trade_screen.dart
@@ -1,10 +1,41 @@
+import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import '../shared/balance_view.dart';
+import 'forex_quote.dart';
 
-class TradeScreen extends StatelessWidget {
+class TradeScreen extends StatefulWidget {
   const TradeScreen({super.key});
+
+  @override
+  State<TradeScreen> createState() => _TradeScreenState();
+}
+
+class _TradeScreenState extends State<TradeScreen> {
+  late Future<List<ForexQuote>> _future;
+  final _dio = Dio();
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<List<ForexQuote>> _load() async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      'https://fcsapi.com/api-v3/forex/latest',
+      queryParameters: {
+        'symbol': 'all_forex',
+        'access_key': 'MMYvxViGmOGIrdFgXXXX6fSAeZiOJGng',
+      },
+    );
+    final data = response.data?['response'] as List<dynamic>? ?? [];
+    return data
+        .map((e) => ForexQuote.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,8 +44,34 @@ class TradeScreen extends StatelessWidget {
         title: Text(tr('nav.trade')),
         actions: const [BalanceView()],
       ),
-      body: const Center(
-        child: Text('Trading screen placeholder'),
+      body: FutureBuilder<List<ForexQuote>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text(snapshot.error.toString()));
+          }
+          final quotes = snapshot.data?.take(10).toList() ?? [];
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: LineChart(
+              LineChartData(
+                titlesData: FlTitlesData(show: false),
+                borderData: FlBorderData(show: false),
+                lineBarsData: [
+                  LineChartBarData(
+                    spots: [
+                      for (var i = 0; i < quotes.length; i++)
+                        FlSpot(i.toDouble(), quotes[i].price),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   go_router: ^10.1.2
   easy_localization: ^3.0.3
   webview_flutter: ^4.0.7
+  fl_chart: ^0.63.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- fetch learning articles from backend API and display in WebView with reward on exit
- centralize API base client and fix brokers screen fetching
- add forex data chart to trading page using FCS API

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68938c187cc0832db314e89005e138f9